### PR TITLE
Fix prop analytics is undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,7 @@ typings/
 # next.js build output
 .next
 
+# yarn.lock
+yarn.lock
+
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,4 @@ typings/
 # next.js build output
 .next
 
-# yarn.lock
-yarn.lock
-
 dist

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { Component, createElement } from "react";
 import * as prodLytics from "./analytics/prod";
-import * as devLytics from "./analytics/dev"
+import * as devLytics from "./analytics/dev";
 
 function isLocal(host) {
   return location.hostname === host;
@@ -12,6 +12,10 @@ function isDev() {
 
 export default (code, Router, { localhost = "localhost" } = {}) => Page => {
   class WithAnalytics extends Component {
+    state = {
+      analytics: undefined
+    };
+
     componentDidMount() {
       // check if it should track
       const shouldNotTrack = isLocal(localhost) || isDev();
@@ -24,7 +28,7 @@ export default (code, Router, { localhost = "localhost" } = {}) => Page => {
       this.analytics.pageview();
 
       // save possible previously defined callback
-      const previousCallback = Router.onRouteChangeComplete
+      const previousCallback = Router.onRouteChangeComplete;
       Router.onRouteChangeComplete = () => {
         // call previously defined callback if is a function
         if (typeof previousCallback === "function") {
@@ -32,11 +36,18 @@ export default (code, Router, { localhost = "localhost" } = {}) => Page => {
         }
         // log page
         this.analytics.pageview();
-      }
+      };
+
+      this.setState({
+        analytics
+      });
     }
 
     render() {
-      return createElement(Page, { ...this.props, analytics: this.analytics });
+      return createElement(Page, {
+        ...this.props,
+        analytics: this.state.analytics
+      });
     }
   }
 


### PR DESCRIPTION
First. Thanks for that simple, yet great component!

## Goal
Use initialized `react-ga` to track further events (`event`, `outboundLink`,...) inside mounted components / pages.

## Current state
```js
// Example

// _app.js
...
<Component analytics={this.props.analytics} {...pageProps} />
...

// somepage.js
...
<Button
    title="Create User"
    onClick={() => 
        props.analytics.event({
            category: 'User',
            action: 'Created an Account'
        });
    }
/>
...

// --> Error
console.log(props.analytics) // --> undefined
```

## Issue
* next-ga is initialized on client only (`componentDidMount`)
* Page (`somepage.js`) is rendered on server: `analytics` is undefined
* Prop `analytics` won't be updated

## Suggested solution
Keep reference to `analytics` in local state of HoC component to trigger a rerender on change