### PR TITLE
more methods and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,62 @@ import Router from "next/router";
 import withGA from "next-ga";
 ```
 
+Available arguments:
+|Value|Notes|
+|------|-----|
+|configsOrTrackingId| `String`. Required. GA Tracking ID like `UA-000000-01` or `Array` of multiple trackers `Objects` passed to [`ReactGa.initialize()`](https://github.com/react-ga/react-ga#reactgainitializegatrackingid-options) method as the first argument.|
+|Router| `Object`. Required. next Router.|
+|initOptions| `Object`. Optional. configurations passed to [`ReactGa.initialize()`](https://github.com/react-ga/react-ga#reactgainitializegatrackingid-options) method as the second argument.|
+|fieldsObject| `Object`. Optional. [configurable field names (excluding GA create only fields)](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference). It will be passed as the first argument to [`ReactGa.set()`](https://github.com/react-ga/react-ga#reactgasetfieldsobject)|
+|trackerNames| `Array`. Optional. A list of extra trackers to run the command on. it will be passed as the second argument to [`ReactGa.set()`](https://github.com/react-ga/react-ga#reactgasetfieldsobject)|
+
+
 Wrap your [custom App container](https://nextjs.org/docs#custom-%3Capp%3E) with it
 
 ```js
-// pass your GA code as first argument
+// the only two required arguments is the configsOrTrackingId and Router
 export default withGA("UA-xxxxxxxxx-1", Router)(MyApp);
+// examples
+export default withGA(
+  "UA-xxxxxxxxx-1", // trackingId
+  Router, // next Router
+  null, // optional initOptions
+  { userId: 123, cd1: "online" } //fieldObjects
+)(MyApp);
+
+export default withGA(
+  "UA-xxxxxxxxx-1", // trackingId
+  Router, // next Router
+  // initOptions
+  {
+    debug: true,
+    titleCase: false,
+    gaOptions: {
+      userId: 123
+    }
+  }
+)(MyApp);
+
+export default withGA(
+  // multiple trackers
+  [
+    {
+      trackingId: "UA-000000-01",
+      gaOptions: {
+        name: "tracker1",
+        userId: 123
+      }
+    },
+    {
+      trackingId: "UA-000000-02",
+      gaOptions: { name: "tracker2" }
+    }
+  ],
+  Router, // next Router
+  { debug: true, alwaysSendToDefaultTracker: false }, // initOptions
+  { userId: 123, cd1: "online" }, // fieldsObject
+  ["tracker2"] // trackersNames
+)(MyApp);
 ```
 
 That's it, now when the user access a page it will log a pageview to Google Analytics, each page change after that will also trigger a pageview on Google Analytics.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ import withGA from "next-ga";
 ```
 
 Available arguments:
+
 |Value|Notes|
 |------|-----|
 |configsOrTrackingId| `String`. Required. GA Tracking ID like `UA-000000-01` or `Array` of multiple trackers `Objects` passed to [`ReactGa.initialize()`](https://github.com/react-ga/react-ga#reactgainitializegatrackingid-options) method as the first argument.|

--- a/src/analytics/dev.js
+++ b/src/analytics/dev.js
@@ -2,24 +2,40 @@ import debug from "debug";
 
 const log = debug("analytics");
 
-export function init(code) {
-  log(`Analytics init triggered for ${code}`);
+export function init(configsOrTrackingId, initOptions) {
+  if (initOptions) {
+    log(
+      `Analytics init triggered for ${configsOrTrackingId} with the following options ${initOptions}`
+    );
+  } else {
+    log(`Analytics init triggered for ${configsOrTrackingId}`);
+  }
+}
+
+export function set(fieldsObject, trackerNames) {
+  if (trackerNames) {
+    log(
+      `Set triggered with the following fieldsObject ${fieldsObject} for those trackers ${trackerNames}`
+    );
+  } else {
+    log(`Set triggered with the following fieldsObject ${fieldsObject}`);
+  }
 }
 
 export function pageview() {
   log(`Pageview triggered for ${window.location.pathname}`);
 }
 
-export function event(category = "", action = "") {
+export function event(options) {
   log(
-    `Event for category ${category} and action ${action} triggered`
+    `Event for category ${options.category} and action ${
+      options.action
+    } triggered`
   );
 }
 
 export function exception(description = "", fatal = false) {
   log(
-    `${
-      fatal ? "Fatal exception" : "Exception"
-    } with description ${description}`
+    `${fatal ? "Fatal exception" : "Exception"} with description ${description}`
   );
 }

--- a/src/analytics/prod.js
+++ b/src/analytics/prod.js
@@ -2,9 +2,21 @@ import ReactGA from "react-ga";
 
 const IS_BROWSER = typeof window !== "undefined";
 
-export function init(code) {
-  if (IS_BROWSER && !window.GA_INITIALIZED && code) {
-    ReactGA.initialize(code);
+export function init(configsOrTrackingId, initOptions) {
+  if (IS_BROWSER && !window.GA_INITIALIZED && configsOrTrackingId) {
+    if (initOptions) {
+      ReactGA.initialize(configsOrTrackingId, initOptions);
+    } else {
+      ReactGA.initialize(configsOrTrackingId);
+    }
+  }
+}
+
+export function set(fieldsObject, trackerNames) {
+  if (trackerNames) {
+    ReactGA.set(fieldsObject, trackerNames);
+  } else {
+    ReactGA.set(fieldsObject);
   }
 }
 
@@ -13,9 +25,9 @@ export function pageview() {
   ReactGA.pageview(window.location.pathname);
 }
 
-export function event(category = "", action = "") {
-  if (category && action) {
-    ReactGA.event({ category, action });
+export function event(options) {
+  if (options.category && options.action) {
+    ReactGA.event(options);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,14 @@ function isDev() {
   return process.env.NODE_ENV !== "production";
 }
 
-export default (code, Router, { localhost = "localhost" } = {}) => Page => {
+export default (
+  conifgsOrTrackingId,
+  Router,
+  initOptions,
+  fieldsObject,
+  trackerNames,
+  { localhost = "localhost" } = {}
+) => Page => {
   class WithAnalytics extends Component {
     state = {
       analytics: undefined
@@ -23,7 +30,21 @@ export default (code, Router, { localhost = "localhost" } = {}) => Page => {
       const analytics = shouldNotTrack ? devLytics : prodLytics;
 
       // init analytics
-      analytics.init(code);
+      if (initOptions) {
+        analytics.init(conifgsOrTrackingId, initOptions);
+      } else {
+        analytics.init(conifgsOrTrackingId);
+      }
+      // set a group of field/value pairs on a tracker object.
+      if (fieldsObject) {
+        if (trackerNames && trackerNames.length) {
+          // multiple trackers
+          analytics.set(fieldsObject, trackerNames);
+        } else {
+          // default tracker
+          analytics.set(fieldsObject);
+        }
+      }
       // log page
       analytics.pageview();
 


### PR DESCRIPTION
1. added `analytics.set()` method which calls `ReactGA.set()` with a required argument `fieldsObject` and optional argument `trackerNames`.
2. `analytics.init()`: modified the first argument to be `configsOrTrackingId` which is the trackingId as a string or array of multiple trackers objects and added `initOptions` object as a second optional argument.
3. modified `ReactGA.event()`: now it accepts only one argument `options` object that requires at least `category` and `action` as properties.