### PR TITLE
Add the ability to respect Do Not Track

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,26 @@ function isDev() {
   return process.env.NODE_ENV !== "production";
 }
 
-export default (code, Router, { localhost = "localhost" } = {}) => Page => {
+const dntEnabled = (window) => {
+  if (
+    window.doNotTrack ||
+    navigator.doNotTrack ||
+    navigator.msDoNotTrack ||
+    "msTrackingProtectionEnabled" in window.external
+  ) {
+    if (
+      window.doNotTrack === "1" ||
+      navigator.doNotTrack === "yes" ||
+      navigator.doNotTrack === "1" ||
+      navigator.msDoNotTrack === "1" ||
+      window.external.msTrackingProtectionEnabled()
+    ) {
+      return true;
+    }
+  }
+}
+
+export default (code, Router, { localhost = "localhost", respectDNT = false } = {}) => Page => {
   class WithAnalytics extends Component {
     state = {
       analytics: undefined
@@ -18,7 +37,7 @@ export default (code, Router, { localhost = "localhost" } = {}) => Page => {
 
     componentDidMount() {
       // check if it should track
-      const shouldNotTrack = isLocal(localhost) || isDev();
+      const shouldNotTrack = (respectDNT && dntEnabled(window)) || isLocal(localhost) || isDev();
       // check if it should use production or dev analytics
       const analytics = shouldNotTrack ? devLytics : prodLytics;
 


### PR DESCRIPTION
This PR adds an additional setting `respectDNT` that allows developers to respect a user's `Do Not Track` setting. When `Do Not Track` is enabled on a user's machine, `next-ga` would simply not send events to GA – in the same fashion as when the user is in a local or dev environment.

Of course, in order to avoid breaking changes, `respectDNT` is set to `false` by default. 

### Usage

In the same object that a developer would specify `localhost`, they can specify a `respectDNT` property that would allow the behavior mentioned above to happen.

```js
import Router from 'next/router'
import App from 'next/app'
import withGA from 'next-ga'

export default withGA('UA-XXXXXXXX-X', Router, { respectDNT: true })(App)
```

### Implementation Details

In addition to checking whether or not the user is in a local environment or if `NODE_ENV` is `production`, `next-ga` would also perform a `dntEnabled(window)` check (if `respectDNT` is set)

```diff
- const shouldNotTrack = isLocal(localhost) || isDev()
+ const shouldNotTrack = (respectDNT && dntEnabled(window)) || isLocal(localhost) || isDev()
```

#### `dntEnabled(window)` check

To check whether or not the user has set `Do Not Track`, we check via browser APIs for this:

```js
const dntEnabled = (window) => {
  if (
    window.doNotTrack ||
    navigator.doNotTrack ||
    navigator.msDoNotTrack ||
    "msTrackingProtectionEnabled" in window.external
  ) {
    if (
      window.doNotTrack === "1" ||
      navigator.doNotTrack === "yes" ||
      navigator.doNotTrack === "1" ||
      navigator.msDoNotTrack === "1" ||
      window.external.msTrackingProtectionEnabled()
    ) {
      return true;
    }
  }
}
```

Reference Docs for DNT detection: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack 

Let me know if you need any changes or if there is an existing alternative for doing something like this.

Thank you for your time. :wave: 